### PR TITLE
Event

### DIFF
--- a/include/EventQueue/Event.hpp
+++ b/include/EventQueue/Event.hpp
@@ -64,3 +64,12 @@ using Event = std::variant<PlayEvent,
                            AudioFinishedEvent,
                            AudioErrorEvent,
                            ShutdownEvent>;
+
+template <typename T>
+concept EventType = std::same_as<T, PlayEvent> ||
+                    std::same_as<T, ResumeEvent> ||
+                    std::same_as<T, PauseEvent> ||
+                    std::same_as<T, StopEvent> ||
+                    std::same_as<T, ShutdownEvent> ||
+                    std::same_as<T, AudioFinishedEvent> ||
+                    std::same_as<T, AudioErrorEvent>;

--- a/include/EventQueue/Event.hpp
+++ b/include/EventQueue/Event.hpp
@@ -8,6 +8,7 @@
 #include <string>
 #include <boost/filesystem.hpp>
 #include <variant>
+#include <optional>
 
 using identifier_type = uint64_t;
 using name_type = std::string;
@@ -49,9 +50,11 @@ struct AudioFinishedEvent
 
 struct AudioErrorEvent
 {
-    explicit AudioErrorEvent(const identifier_type id, std::string s)
+    AudioErrorEvent(std::optional<identifier_type>&& id, std::string s)
+    : id(std::move(id)), error_msg(std::move(s)) {}
+    AudioErrorEvent(const std::optional<identifier_type>& id, std::string s)
     : id(id), error_msg(std::move(s)) {}
-    identifier_type id;
+    std::optional<identifier_type> id;
     std::string error_msg;
 };
 


### PR DESCRIPTION
AudioErrorEvent may happen when there isn't a valid playback identifier. So now it holds an std::optional<identifier_type>